### PR TITLE
Duplicating objects with custom property of type ID creates bogus links.

### DIFF
--- a/intern/locale/boost_locale_wrapper.cpp
+++ b/intern/locale/boost_locale_wrapper.cpp
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <boost/locale.hpp>
+#include <iostream>
 
 #include "boost_locale_wrapper.h"
 

--- a/source/blender/blenkernel/intern/library.c
+++ b/source/blender/blenkernel/intern/library.c
@@ -1314,8 +1314,12 @@ void BKE_libblock_copy_ex(Main *bmain, const ID *id, ID **r_newid, const int fla
 		memcpy(cpn + id_offset, cp + id_offset, id_len - id_offset);
 	}
 
+	/* We do not want any handling of usercount in code duplicating the data here, we do that all
+	 * at once in id_copy_libmanagement_cb() at the end. */
+	const int copy_data_flag = flag | LIB_ID_CREATE_NO_USER_REFCOUNT;
+
 	if (id->properties) {
-		new_id->properties = IDP_CopyProperty_ex(id->properties, flag);
+		new_id->properties = IDP_CopyProperty_ex(id->properties, copy_data_flag);
 	}
 
 	/* the duplicate should get a copy of the animdata */


### PR DESCRIPTION
Fix cherry-picked from https://projects.blender.org/blender/blender/commit/0fb55ff845fcaa76d9b540c2fbdd3e1b4671a7e7 and confirmed working with korman as per the test case Jrius shared in Discord.